### PR TITLE
Add support for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.sav
 *.old
 *.pem
+.cache/
 README.html
 build/*
 dist/*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
+# environment variables
+environment:
+  matrix:
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
+
+build: off
+
+# scripts that run after cloning repository
+install:
+  # If there is a newer build queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose but it is problematic because it tends to cancel builds pushed
+  # directly to master instead of just PR builds (or the converse).
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+      https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+      Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+  # Install dependencies
+  # update path to use installed pip and py.test
+  - set PATH=%PYTHON%\\scripts;%PATH%
+  - 'pip install tornado pywinpty pytest'
+test_script:
+  - 'py.test'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ author-email = "thomas@kluyver.me.uk"
 home-page = "https://github.com/takluyver/terminado"
 description-file = "README.rst"
 requires = [
-    "ptyprocess",
+    "ptyprocess;os_name!='nt'",
+    "pywinpty (>=0.4);os_name=='nt' and python_version>='3.5'",
     "tornado (>=4)",
 ]
 classifiers=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ home-page = "https://github.com/takluyver/terminado"
 description-file = "README.rst"
 requires = [
     "ptyprocess;os_name!='nt'",
-    "pywinpty (>=0.4);os_name=='nt' and python_version>='3.5'",
+    "pywinpty (>=0.4.1);os_name=='nt' and python_version>='3.5'",
     "tornado (>=4)",
 ]
 classifiers=[


### PR DESCRIPTION
Relies on https://github.com/spyder-ide/pywinpty/pull/67 and a release.

Note this is for Python 3 only because `pywinpty` does not support Python 2.

Here's a screenshot with ``` export SHELL=`which cmd` ```:

![cmd_term](https://user-images.githubusercontent.com/2096628/32979250-349763f4-cc17-11e7-8254-605bcaf00e83.PNG)

Here it is with ``` export SHELL=`which bash` ```:

![bash_term](https://user-images.githubusercontent.com/2096628/32979289-0db73024-cc18-11e7-9d07-08b41ade9b30.PNG)

Passing build on https://ci.appveyor.com/project/blink1073/terminado/build/1.0.7

I can take care of any Windows related maintenance issues moving forward.