### PR TITLE
Set websocket.terminal to None when the child exits

### DIFF
--- a/terminado/websocket.py
+++ b/terminado/websocket.py
@@ -100,3 +100,4 @@ class TermSocket(tornado.websocket.WebSocketHandler):
         """
         self.send_json_message(['disconnect', 1])
         self.close()
+        self.terminal = None


### PR DESCRIPTION
This fixes an error I was seeing when exiting a terminal which is open in multiple tabs at the same time. The code path to resize the terminal to the smallest client window size was taken, which tries to communicate with the (now closed) terminal:

```
[E 10:17:30.026 NotebookApp] Uncaught exception GET /terminals/websocket/1 (127.0.0.1)
    HTTPServerRequest(protocol='http', host='localhost:8888', method='GET', uri='/terminals/websocket/1', version='HTTP/1.1', remote_ip='127.0.0.1')
    Traceback (most recent call last):
      File "/home/takluyver/.local/lib/python3.6/site-packages/tornado/web.py", line 1499, in _stack_context_handle_exception
        raise_exc_info((type, value, traceback))
      File "<string>", line 4, in raise_exc_info
      File "/home/takluyver/.local/lib/python3.6/site-packages/tornado/stack_context.py", line 315, in wrapped
        ret = fn(*args, **kwargs)
      File "/home/takluyver/.local/lib/python3.6/site-packages/tornado/websocket.py", line 440, in on_connection_close
        self.on_close()
      File "/home/takluyver/.local/lib/python3.6/site-packages/terminado/websocket.py", line 95, in on_close
        self.terminal.resize_to_smallest()
      File "/home/takluyver/.local/lib/python3.6/site-packages/terminado/management.py", line 61, in resize_to_smallest
        rows, cols = self.ptyproc.getwinsize()
      File "/home/takluyver/.local/lib/python3.6/site-packages/ptyprocess/ptyprocess.py", line 772, in getwinsize
        x = fcntl.ioctl(self.fd, TIOCGWINSZ, s)
    ValueError: file descriptor cannot be a negative integer (-1)
```