### PR TITLE
Add python_requires to help pip, and version classifers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,6 @@ classifiers=[
     "Environment :: Web Environment",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.4",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
     "Topic :: Terminals :: Terminal Emulators/X Terminals",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     "pywinpty (>=0.5);os_name=='nt'",
     "tornado (>=4)",
 ]
-python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+requires-python=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 classifiers=[
     "Environment :: Web Environment",
     "License :: OSI Approved :: BSD License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,15 @@ requires = [
     "pywinpty (>=0.5);os_name=='nt'",
     "tornado (>=4)",
 ]
+python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 classifiers=[
     "Environment :: Web Environment",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2",
+    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.4",
+    "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
     "Topic :: Terminals :: Terminal Emulators/X Terminals",
 ]


### PR DESCRIPTION
Based on the versions tested by .travis.yml, which match the supported CPython versions.

https://en.wikipedia.org/wiki/CPython#Version_history

And here's the pip installs for terminado from PyPI for May 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  41.87% |        136,449 |
| 3.6            |  26.07% |         84,967 |
| 3.5            |  18.60% |         60,618 |
| 3.4            |  13.15% |         42,869 |
| 3.7            |   0.27% |            876 |
| 3.3            |   0.03% |            103 |
| 2.6            |   0.00% |             15 |
| 3.8            |   0.00% |              1 |
| Total          |         |        325,898 |

Source: `pypinfo --start-date 2018-05-01 --end-date 2018-05-31 --percent --markdown terminado pyversion`