### PR TITLE
Fix for https://github.com/jupyter/terminado/issues/62

### DIFF
--- a/terminado/management.py
+++ b/terminado/management.py
@@ -86,7 +86,7 @@ class PtyWithClients(object):
                        signal.SIGTERM]
 
         loop = IOLoop.current()
-        sleep = lambda : gen.Task(loop.add_timeout, loop.time() + self.ptyproc.delayafterterminate)
+        sleep = lambda : gen.sleep(self.ptyproc.delayafterterminate)
 
         if not self.ptyproc.isalive():
             raise gen.Return(True)


### PR DESCRIPTION
Jupyter brings in latest tornado version 6.0.1 and it breaks Jupyter Terminal due to removing
of gen.Task in earlier version, https://www.tornadoweb.org/en/stable/releases/v6.0.0.html
