### PR TITLE
Add kwargs to NamedTermManager.new_named_terminal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
   - "3.6"

--- a/terminado/management.py
+++ b/terminado/management.py
@@ -314,9 +314,9 @@ class NamedTermManager(TermManagerBase):
             if name not in self.terminals:
                 return name
 
-    def new_named_terminal(self):
+    def new_named_terminal(self, **kwargs):
         name = self._next_available_name()
-        term = self.new_terminal()
+        term = self.new_terminal(**kwargs)
         self.log.info("New terminal with automatic name: %s", name)
         term.term_name = name
         self.terminals[name] = term


### PR DESCRIPTION
Hi, I am trying to fix this issue jupyterlab/jupyterlab#1366 in jupyterlab so that terminals open in the current working directory. 

In order to do this, we need to be able to pass key word arguments to the `new_terminal` call in `new_named_terminal` so that the jupyter server can create terminals with different working directories.

https://github.com/jupyter/terminado/blob/b0b32f3efdde4252466f4e57b98773d9e86951ec/terminado/management.py#L317-L324