### PR TITLE
Don't call getpgid() when killing a test

### DIFF
--- a/terminado/management.py
+++ b/terminado/management.py
@@ -70,8 +70,7 @@ class PtyWithClients(object):
         """Send a signal to the process group of the process in the pty"""
         if os.name == 'nt':
             return self.ptyproc.kill(sig)
-        pgid = os.getpgid(self.ptyproc.pid)
-        os.killpg(pgid, sig)
+        os.killpg(self.ptyproc.pid, sig)
     
     @gen.coroutine
     def terminate(self, force=False):


### PR DESCRIPTION
OpenBSD's getpgid(2) fails with EPERM (PermissionError) because the test is in a different session: https://man.openbsd.org/getpgid.

e.g.:

```
________________________ CommonTests.test_basic_command ________________________
/usr/local/lib/python3.7/site-packages/tornado/testing.py:451: in tearDown
    super(AsyncHTTPTestCase, self).tearDown()
/usr/local/lib/python3.7/site-packages/tornado/testing.py:222: in tearDown
    self.__rethrow()
/usr/local/lib/python3.7/site-packages/tornado/testing.py:250: in __rethrow
    raise_exc_info(failure)
/usr/local/lib/python3.7/site-packages/tornado/stack_context.py:339: in wrapped
    ret = fn(*args, **kwargs)
/usr/local/lib/python3.7/site-packages/tornado/websocket.py:488: in on_connection_close
    self.on_close()
terminado/websocket.py:96: in on_close
    self.term_manager.client_disconnected(self)
terminado/management.py:281: in client_disconnected
    websocket.terminal.killpg(signal.SIGHUP)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <terminado.management.PtyWithClients object at 0x102077282a10>
sig = <Signals.SIGHUP: 1>

    def killpg(self, sig=signal.SIGTERM):
        """Send a signal to the process group of the process in the pty"""
        if os.name == 'nt':
            return self.ptyproc.kill(sig)
>       pgid = os.getpgid(self.ptyproc.pid)
E       PermissionError: [Errno 1] Operation not permitted

terminado/management.py:73: PermissionError
```

Use self.ptyproc.pid as the process group ID, because setsid() created a process group with the same ID as the process. See setsid(2) manuals:

 - OpenBSD: https://man.openbsd.org/setsid
 - FreeBSD: https://www.freebsd.org/cgi/man.cgi?query=setsid
 - illumos: https://illumos.org/man/setsid
 - Linux: http://man7.org/linux/man-pages/man2/setsid.2.html