### PR TITLE
Drop python 2 and 3.4 and 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-dist: trusty
+os: linux
+dist: focal
 language: python
 python:
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ dist: trusty
 language: python
 python:
   - "3.6"
-  - "3.5"
-  - "3.4"
-  - "2.7"
+  - "3.7"
+  - "3.8"
 
 # Install dependencies
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,8 @@ skip_branch_with_pr: true
 # environment variables
 environment:
   matrix:
-    - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python38-x64"
 
 build: off
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     "pywinpty (>=0.5);os_name=='nt'",
     "tornado (>=4)",
 ]
-requires-python=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+requires-python=">=3.6"
 classifiers=[
     "Environment :: Web Environment",
     "License :: OSI Approved :: BSD License",

--- a/terminado/tests/basic_test.py
+++ b/terminado/tests/basic_test.py
@@ -20,6 +20,11 @@ import os
 import re
 import signal
 
+# We must set the policy for python >=3.8, see https://www.tornadoweb.org/en/stable/#installation
+# Snippet from https://github.com/tornadoweb/tornado/issues/2608#issuecomment-619524992
+import sys, asyncio
+if sys.version_info[0]==3 and sys.version_info[1] >= 8 and sys.platform.startswith('win'):
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 #
 # The timeout we use to assume no more messages are coming

--- a/terminado/tests/basic_test.py
+++ b/terminado/tests/basic_test.py
@@ -161,7 +161,10 @@ class CommonTests(TermTestCase):
             response = yield tm.read_msg()
             self.assertEqual(response[0], 'stdout')
             self.assertGreater(len(response[1]), 0)
+            pid = yield tm.get_pid()
             tm.close()
+            if os.name == 'nt':
+                os.kill(pid, 15)
 
     @tornado.testing.gen_test
     def test_basic_command(self):

--- a/terminado/tests/basic_test.py
+++ b/terminado/tests/basic_test.py
@@ -18,6 +18,7 @@ import logging
 import json
 import os
 import re
+import signal
 
 
 #
@@ -164,7 +165,7 @@ class CommonTests(TermTestCase):
             pid = yield tm.get_pid()
             tm.close()
             if os.name == 'nt':
-                os.kill(pid, 15)
+                os.kill(pid, signal.CTRL_BREAK_EVENT)
 
     @tornado.testing.gen_test
     def test_basic_command(self):

--- a/terminado/tests/basic_test.py
+++ b/terminado/tests/basic_test.py
@@ -162,10 +162,8 @@ class CommonTests(TermTestCase):
             response = yield tm.read_msg()
             self.assertEqual(response[0], 'stdout')
             self.assertGreater(len(response[1]), 0)
-            pid = yield tm.get_pid()
-            tm.close()
-            if os.name == 'nt':
-                os.kill(pid, signal.CTRL_BREAK_EVENT)
+            tm.close()        
+        tm.kill_all()
 
     @tornado.testing.gen_test
     def test_basic_command(self):

--- a/terminado/tests/basic_test.py
+++ b/terminado/tests/basic_test.py
@@ -124,6 +124,12 @@ class TermTestCase(tornado.testing.AsyncHTTPTestCase):
 
         raise tornado.gen.Return(pids)
 
+    def tearDown(self):
+        self.named_tm.kill_all()
+        self.single_tm.kill_all()
+        self.unique_tm.kill_all()
+        super().tearDown()
+
     def get_app(self):
         self.named_tm = NamedTermManager(shell_command=['bash'], 
                                             max_terminals=MAX_TERMS,
@@ -163,7 +169,6 @@ class CommonTests(TermTestCase):
             self.assertEqual(response[0], 'stdout')
             self.assertGreater(len(response[1]), 0)
             tm.close()        
-        tm.kill_all()
 
     @tornado.testing.gen_test
     def test_basic_command(self):


### PR DESCRIPTION
Python 2 and 3.4 have reached EOL, and 3.5 will soon reach EOL.