### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 os: linux
+arch:
+  - amd64
+  - ppc64le
 dist: focal
 language: python
 python:


### PR DESCRIPTION
Add support to ppc64le (Linux on Power little endian) architecture. terminado is part of ubuntu distribution on ppc64le as well.
Continuously running the build/test on this will ensure that we detect/fix any issues on an ongoing basis and helping in keeping it up to date