### PR TITLE
Make sure SIGPIPE has default handler set

### DIFF
--- a/terminado/management.py
+++ b/terminado/management.py
@@ -43,7 +43,8 @@ class PtyWithClients(object):
         # We keep the same read_buffer as before
         self.read_buffer = deque([], maxlen=10)
         self.preopen_buffer = deque([])
-        self.ptyproc = PtyProcessUnicode.spawn(argv, env=env, cwd=cwd)
+        self.ptyproc = PtyProcessUnicode.spawn(argv, env=env, cwd=cwd,
+            preexec_fn=lambda: signal.signal(signal.SIGPIPE, signal.SIG_DFL))
 
     def resize_to_smallest(self):
         """Set the terminal size to that of the smallest client dimensions.


### PR DESCRIPTION
When spawning individual servers in a way that has systemd as an ancestor somewhere up the process tree (e.g. using `SystemdSpawner`), the server inherits systemd's default of [ignoring SIGPIPE](https://lists.freedesktop.org/archives/systemd-devel/2014-August/021982.html). This in turn means that if you start a terminal inside the individual server and run pipelines, you can come across `Broken pipe` errors which you wouldn't normally see in an interactive shell that has default SIGPIPE handling:

```sh
user@host:~/ls20-21$ yes | head
y
y
y
y
y
y
y
y
y
y
yes: standard output: Broken pipe
```

(See [this post on the Jupyter Discourse](https://discourse.jupyter.org/t/unexpected-broken-pipe-errors-in-the-jupyterlab-terminal/8297) for more details.)

The systemd-devel mailing list post linked in the first paragraph suggests that "Of course, shells and suchlike should turn this [i.e. SIGPIPE handling] on again." So this is what this PR does :) Let me know though if this should be handled somewhere else, I'm keen to follow through and do everything I can to have this fixed, as it affects my own setup and teaching.