### PR TITLE
Fix blocking of pty_read when there isn't pty data ready to read

### DIFF
--- a/terminado/management.py
+++ b/terminado/management.py
@@ -14,6 +14,7 @@ import os
 import signal
 import codecs
 import warnings
+import select
 
 try:
     from ptyprocess import PtyProcessUnicode
@@ -205,6 +206,9 @@ class TermManagerBase(object):
 
     def pty_read(self, fd, events=None):
         """Called by the event loop when there is pty data ready to read."""
+        r, _, _ = select.select([fd], [], [], .1)
+        if not r:
+            return
         ptywclients = self.ptys_by_fd[fd]
         try:
             s = ptywclients.ptyproc.read(65536)


### PR DESCRIPTION
related issue: #106 

It seems that sometimes if there is no data ready, it will also trigger the execution of this function, and blocking the entire main thread. This phenomenon is very similar to a deadlock, so another judgment is added to ptyread to avoid this situation.