### PR TITLE
Clean up tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, windows]
-        python-version: ["3.6", "3.8", "3.9"]
+        os: [ubuntu, macos, windows]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
+        exclude:
+          - os: windows
+            python-version: pypy3
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -45,8 +48,8 @@ jobs:
       - name: Run the tests
         if: ${{ matrix.os != 'windows' }}
         run: |
-          pytest -vv -s
+          pytest -vv -s || pytest -vv -s --lf
       - name: Run basic test on Windows
         if: ${{ matrix.os == 'windows' }}
         run: |
-          pytest -vv
+          pytest -vv || pytest -vv --lf

--- a/terminado/tests/basic_test.py
+++ b/terminado/tests/basic_test.py
@@ -20,6 +20,7 @@ import os
 import re
 import signal
 import pytest
+from sys import platform
 
 # We must set the policy for python >=3.8, see https://www.tornadoweb.org/en/stable/#installation
 # Snippet from https://github.com/tornadoweb/tornado/issues/2608#issuecomment-619524992
@@ -216,7 +217,7 @@ class NamedTermTests(TermTestCase):
         self.assertNotEqual(pids[0], pids[3])
 
     @tornado.testing.gen_test
-    @pytest.mark.skipif(os.name == 'nt', reason='It fails on Windows')
+    @pytest.mark.skipif('linux' not in platform, reason='It only works on Linux')
     async def test_max_terminals(self):
         urls = ["/named/%d" % i for i in range(MAX_TERMS+1)]
         tms = await self.get_term_clients(urls[:MAX_TERMS])
@@ -242,7 +243,7 @@ class UniqueTermTests(TermTestCase):
         self.assertNotEqual(pids[0], pids[1])
 
     @tornado.testing.gen_test
-    @pytest.mark.skipif(os.name == 'nt', reason='It fails on Windows')
+    @pytest.mark.skipif('linux' not in platform, reason='It only works on Linux')
     async def test_max_terminals(self):
         tms = await self.get_term_clients(['/unique'] * MAX_TERMS)
         pids = await self.get_pids(tms)


### PR DESCRIPTION
* Expand test matrix to include all supported versions except pypy on Windows which lacks a published wheel for pywinpty and results in an install failure
* Retry failed tests
* Skip flaky max_terminals tests on all platforms but Linux