### PR TITLE
correctly set the TERM variable

### DIFF
--- a/terminado/management.py
+++ b/terminado/management.py
@@ -28,7 +28,7 @@ from tornado.ioloop import IOLoop
 
 ENV_PREFIX = "PYXTERM_"         # Environment variable prefix
 
-DEFAULT_TERM_TYPE = "xterm"
+DEFAULT_TERM_TYPE = "xterm-256color"
 
 
 class PtyWithClients(object):
@@ -172,7 +172,8 @@ class TermManagerBase(object):
     def make_term_env(self, height=25, width=80, winheight=0, winwidth=0, **kwargs):
         """Build the environment variables for the process in the terminal."""
         env = os.environ.copy()
-        env["TERM"] = self.term_settings.get("type", DEFAULT_TERM_TYPE)
+        if "TERM" not in env or "type" in self.term_settings:
+            env["TERM"] = self.term_settings.get("type", DEFAULT_TERM_TYPE)
         dimensions = "%dx%d" % (width, height)
         if winwidth and winheight:
             dimensions += ";%dx%d" % (winwidth, winheight)


### PR DESCRIPTION

fix for https://github.com/jupyterlab/jupyterlab/issues/3413, explanation of the fixes is on the issue.

* the default TERM to xterm-256color
* only override TERM if its not previously set
