### PR TITLE
Fix terminal output logging type error

### DIFF
--- a/terminado/tests/basic_test.py
+++ b/terminado/tests/basic_test.py
@@ -39,6 +39,8 @@ MAX_TERMS = 3                               # Testing thresholds
 
 class TestTermClient(object):
     """Test connection to a terminal manager"""
+    __test__ = False
+
     def __init__(self, websocket):
         self.ws = websocket
         self.pending_read = None

--- a/terminado/tests/basic_test.py
+++ b/terminado/tests/basic_test.py
@@ -14,11 +14,9 @@ from tornado.httpclient import HTTPError
 from tornado.ioloop import IOLoop
 import tornado.testing
 import datetime
-import logging
 import json
 import os
 import re
-import signal
 import pytest
 from sys import platform
 


### PR DESCRIPTION
Resolve #121 (terminal output logging type error) by refactoring message content checks.

Move `LOG_TERMINAL_OUTPUT` env variable check into initialize, and check flag before preparing messages to send for performance.
Fix `PytestCollectionWarning: cannot collect test class 'TestTermClient'` due to incorrect test discovery.