### PR TITLE
Automated Changelog Entry for 0.12.2 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.12.2
+
+([Full Changelog](https://github.com/jupyter/terminado/compare/0.12.1...eea43b51a25be52e2e53334f94a5005a22d12109))
+
+### Bugs fixed
+
+- Use read_buffer for reconnect and remove preopen_buffer [#127](https://github.com/jupyter/terminado/pull/127) ([@Wh1isper](https://github.com/Wh1isper))
+
+### Maintenance and upkeep improvements
+
+- Run CI Daily [#125](https://github.com/jupyter/terminado/pull/125) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter/terminado/graphs/contributors?from=2021-09-07&to=2022-01-26&type=c))
+
+[@andfoy](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Aandfoy+updated%3A2021-09-07..2022-01-26&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Ablink1073+updated%3A2021-09-07..2022-01-26&type=Issues) | [@Wh1isper](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3AWh1isper+updated%3A2021-09-07..2022-01-26&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.12.1
 
 ([Full Changelog](https://github.com/jupyter/terminado/compare/0.12.0...a70e0bf98a597ce4d1ac5aa6915e70cf6e00789e))
@@ -15,8 +35,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter/terminado/graphs/contributors?from=2021-09-07&to=2021-09-07&type=c))
 
 [@rvalieris](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Arvalieris+updated%3A2021-09-07..2021-09-07&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.12.0
 
@@ -35,7 +53,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter/terminado/graphs/contributors?from=2021-08-18&to=2021-09-07&type=c))
 
 [@hugovk](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Ahugovk+updated%3A2021-08-18..2021-09-07&type=Issues) | [@rvalieris](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Arvalieris+updated%3A2021-08-18..2021-09-07&type=Issues)
-
 
 ## 0.11.1
 
@@ -99,7 +116,6 @@
 
 - async/await syntax [#103](https://github.com/jupyter/terminado/pull/103) ([@minrk](https://github.com/minrk))
 - PR: Pin pywinpty version to 1.1.0 [#101](https://github.com/jupyter/terminado/pull/101) ([@andfoy](https://github.com/andfoy))
-
 
 ### Contributors to this release
 


### PR DESCRIPTION
Automated Changelog Entry for 0.12.2 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter/terminado  |
| Branch  | main  |
| Version Spec | next |
| Since | 0.12.1 |