### PR TITLE
Automated Changelog Entry for 0.12.3 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.12.3
+
+([Full Changelog](https://github.com/jupyter/terminado/compare/v0.12.2...d0510462c73663790bdb0ae87640b7565866d1f9))
+
+### Bugs fixed
+
+- Fix terminal output logging type error [#122](https://github.com/jupyter/terminado/pull/122) ([@devmonkey22](https://github.com/devmonkey22))
+
+### Maintenance and upkeep improvements
+
+- Fix formatting of trove classifiers [#129](https://github.com/jupyter/terminado/pull/129) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter/terminado/graphs/contributors?from=2022-01-26&to=2022-01-26&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Ablink1073+updated%3A2022-01-26..2022-01-26&type=Issues) | [@devmonkey22](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Adevmonkey22+updated%3A2022-01-26..2022-01-26&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.12.2
 
 ([Full Changelog](https://github.com/jupyter/terminado/compare/0.12.1...eea43b51a25be52e2e53334f94a5005a22d12109))
@@ -19,8 +39,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter/terminado/graphs/contributors?from=2021-09-07&to=2022-01-26&type=c))
 
 [@andfoy](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Aandfoy+updated%3A2021-09-07..2022-01-26&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Ablink1073+updated%3A2021-09-07..2022-01-26&type=Issues) | [@Wh1isper](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3AWh1isper+updated%3A2021-09-07..2022-01-26&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.12.1
 


### PR DESCRIPTION
Automated Changelog Entry for 0.12.3 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter/terminado  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.12.2 |