### PR TITLE
python_requires is an option in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,6 @@ url = https://github.com/jupyter/terminado
 description = Tornado websocket backend for the Xterm.js Javascript terminal emulator library.
 description_file = README.rst
 long_description_content_type = text/x-rst
-python_requires= >=3.7
 classifiers =
     Environment :: Web Environment
     License :: OSI Approved :: BSD License
@@ -17,6 +16,7 @@ classifiers =
 [options]
 include_package_data = True
 packages = find:
+python_requires= >=3.7
 install_requires =
     ptyprocess;os_name!='nt'
     pywinpty (>=1.1.0);os_name=='nt'


### PR DESCRIPTION
not metadata, where it's being ignored.

As a result, terminado 0.13 lacks the python_requires metadata, and will be selected for installation on old, incompatible Pythons.

[ref](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html)