### PR TITLE
Automated Changelog Entry for 0.13.3 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.13.3
+
+([Full Changelog](https://github.com/jupyter/terminado/compare/v0.13.2...2cccad61af7e7ec88e4db769664d8814985179d4))
+
+### Bugs fixed
+
+- Test ConPTY backend against pywinpty 2.0.5 [#146](https://github.com/jupyter/terminado/pull/146) ([@andfoy](https://github.com/andfoy))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter/terminado/graphs/contributors?from=2022-03-03&to=2022-03-07&type=c))
+
+[@andfoy](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Aandfoy+updated%3A2022-03-03..2022-03-07&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Ablink1073+updated%3A2022-03-03..2022-03-07&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.13.2
 
 ([Full Changelog](https://github.com/jupyter/terminado/compare/v0.13.1...9db93006a960bc90c3cc6b3f53b5cba1251b5071))
@@ -19,8 +35,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter/terminado/graphs/contributors?from=2022-01-27&to=2022-03-03&type=c))
 
 [@andfoy](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Aandfoy+updated%3A2022-01-27..2022-03-03&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Ablink1073+updated%3A2022-01-27..2022-03-03&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Afcollonval+updated%3A2022-01-27..2022-03-03&type=Issues) | [@Wh1isper](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3AWh1isper+updated%3A2022-01-27..2022-03-03&type=Issues) | [@yusufbashi](https://github.com/search?q=repo%3Ajupyter%2Fterminado+involves%3Ayusufbashi+updated%3A2022-01-27..2022-03-03&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.13.1
 


### PR DESCRIPTION
Automated Changelog Entry for 0.13.3 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter/terminado  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.13.2 |