### PR TITLE
Fix issue where large stdin writes can cause Tornado to hang

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,16 @@ jobs:
         with:
           package_name: jupyter_server_terminals
 
+  spyder-terminal:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        with:
+          package_name: spyter-terminal
+
   # Run "pre-commit run --all-files --hook-stage=manual"
   pre-commit:
     name: Run pre-commit hook

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,16 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
 
+  jupyter_server_terminals:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
+        with:
+          package_name: jupyter_server_terminals
+
   # Run "pre-commit run --all-files --hook-stage=manual"
   pre-commit:
     name: Run pre-commit hook

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
-          package_name: spyter-terminal
+          package_name: spyder-terminal
 
   # Run "pre-commit run --all-files --hook-stage=manual"
   pre-commit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,16 +111,6 @@ jobs:
         with:
           package_name: jupyter_server_terminals
 
-  spyder-terminal:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v2
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
-        with:
-          package_name: spyder-terminal
-
   # Run "pre-commit run --all-files --hook-stage=manual"
   pre-commit:
     name: Run pre-commit hook

--- a/demos/custom_exec.py
+++ b/demos/custom_exec.py
@@ -1,0 +1,48 @@
+"""Using a custom thread pool for subprocess writes.
+"""
+import tornado.web
+from concurrent import futures
+
+# This demo requires tornado_xstatic and XStatic-term.js
+import tornado_xstatic
+from common_demo_stuff import STATIC_DIR, TEMPLATE_DIR, run_and_show_browser
+
+from terminado import SingleTermManager, TermSocket
+
+
+class TerminalPageHandler(tornado.web.RequestHandler):
+
+    def get(self):
+        return self.render(
+            "termpage.html",
+            static=self.static_url,
+            xstatic=self.application.settings["xstatic_url"],
+            ws_url_path="/websocket",
+        )
+
+
+def main(argv):
+    with futures.ThreadPoolExecutor(max_workers=2) as custom_exec:
+        term_manager = SingleTermManager(shell_command=["bash"],
+                                         blocking_io_executor=custom_exec)
+        handlers = [
+            (r"/websocket", TermSocket, {
+                "term_manager": term_manager
+            }),
+            (r"/", TerminalPageHandler),
+            (r"/xstatic/(.*)", tornado_xstatic.XStaticFileHandler, {
+                "allowed_modules": ["termjs"]
+            }),
+        ]
+        app = tornado.web.Application(
+            handlers,
+            static_path=STATIC_DIR,
+            template_path=TEMPLATE_DIR,
+            xstatic_url=tornado_xstatic.url_maker("/xstatic/"),
+        )
+        app.listen(8765, "localhost")
+        run_and_show_browser("http://localhost:8765/", term_manager)
+
+
+if __name__ == "__main__":
+    main([])

--- a/demos/custom_exec.py
+++ b/demos/custom_exec.py
@@ -1,7 +1,8 @@
 """Using a custom thread pool for subprocess writes.
 """
-import tornado.web
 from concurrent import futures
+
+import tornado.web
 
 # This demo requires tornado_xstatic and XStatic-term.js
 import tornado_xstatic
@@ -11,7 +12,6 @@ from terminado import SingleTermManager, TermSocket
 
 
 class TerminalPageHandler(tornado.web.RequestHandler):
-
     def get(self):
         return self.render(
             "termpage.html",
@@ -23,16 +23,11 @@ class TerminalPageHandler(tornado.web.RequestHandler):
 
 def main(argv):
     with futures.ThreadPoolExecutor(max_workers=2) as custom_exec:
-        term_manager = SingleTermManager(shell_command=["bash"],
-                                         blocking_io_executor=custom_exec)
+        term_manager = SingleTermManager(shell_command=["bash"], blocking_io_executor=custom_exec)
         handlers = [
-            (r"/websocket", TermSocket, {
-                "term_manager": term_manager
-            }),
+            (r"/websocket", TermSocket, {"term_manager": term_manager}),
             (r"/", TerminalPageHandler),
-            (r"/xstatic/(.*)", tornado_xstatic.XStaticFileHandler, {
-                "allowed_modules": ["termjs"]
-            }),
+            (r"/xstatic/(.*)", tornado_xstatic.XStaticFileHandler, {"allowed_modules": ["termjs"]}),
         ]
         app = tornado.web.Application(
             handlers,

--- a/terminado/management.py
+++ b/terminado/management.py
@@ -38,7 +38,6 @@ DEFAULT_TERM_TYPE = "xterm-256color"
 
 
 class PtyWithClients:
-
     def __init__(self, argv, env=None, cwd=None):
         self.clients = []
         # Use read_buffer to store historical messages for reconnection
@@ -154,13 +153,15 @@ def _poll(fd: int, timeout: float = 0.1) -> list:
 class TermManagerBase:
     """Base class for a terminal manager."""
 
-    def __init__(self,
-                 shell_command,
-                 server_url="",
-                 term_settings=None,
-                 extra_env=None,
-                 ioloop=None,
-                 blocking_io_executor=None):
+    def __init__(
+        self,
+        shell_command,
+        server_url="",
+        term_settings=None,
+        extra_env=None,
+        ioloop=None,
+        blocking_io_executor=None,
+    ):
         self.shell_command = shell_command
         self.server_url = server_url
         self.term_settings = term_settings or {}
@@ -171,8 +172,7 @@ class TermManagerBase:
 
         if blocking_io_executor is None:
             self._blocking_io_executor_is_external = False
-            self.blocking_io_executor = futures.ThreadPoolExecutor(
-                max_workers=1)
+            self.blocking_io_executor = futures.ThreadPoolExecutor(max_workers=1)
         else:
             self._blocking_io_executor_is_external = True
             self.blocking_io_executor = blocking_io_executor
@@ -304,7 +304,6 @@ class SingleTermManager(TermManagerBase):
 
 
 class MaxTerminalsReached(Exception):
-
     def __init__(self, max_terminals):
         self.max_terminals = max_terminals
 

--- a/terminado/websocket.py
+++ b/terminado/websocket.py
@@ -8,8 +8,8 @@ import json
 import logging
 import os
 
-from tornado import gen
 import tornado.websocket
+from tornado import gen
 from tornado.concurrent import run_on_executor
 
 
@@ -33,8 +33,7 @@ class TermSocket(tornado.websocket.WebSocketHandler):
         self._user_command = ""
 
         # Enable if the environment variable LOG_TERMINAL_OUTPUT is "true"
-        self._enable_output_logging = str.lower(
-            os.getenv("LOG_TERMINAL_OUTPUT", "false")) == "true"
+        self._enable_output_logging = str.lower(os.getenv("LOG_TERMINAL_OUTPUT", "false")) == "true"
 
     def origin_check(self, origin=None):
         """Deprecated: backward-compat for terminado <= 0.5."""
@@ -130,7 +129,7 @@ class TermSocket(tornado.websocket.WebSocketHandler):
         """
         self._logger.debug(log)
 
-    @run_on_executor(executor='_blocking_io_executor')
+    @run_on_executor(executor="_blocking_io_executor")
     def stdin_to_ptyproc(self, text):
         """Handles stdin messages sent on the websocket.
 

--- a/terminado/websocket.py
+++ b/terminado/websocket.py
@@ -4,12 +4,13 @@
 # Copyright (c) 2014, Ramalingam Saravanan <sarava@sarava.net>
 # Distributed under the terms of the Simplified BSD License.
 
-
 import json
 import logging
 import os
 
+from tornado import gen
 import tornado.websocket
+from tornado.concurrent import run_on_executor
 
 
 def _cast_unicode(s):
@@ -26,12 +27,14 @@ class TermSocket(tornado.websocket.WebSocketHandler):
         self.term_name = ""
         self.size = (None, None)
         self.terminal = None
+        self._blocking_io_executor = term_manager.blocking_io_executor
 
         self._logger = logging.getLogger(__name__)
         self._user_command = ""
 
         # Enable if the environment variable LOG_TERMINAL_OUTPUT is "true"
-        self._enable_output_logging = str.lower(os.getenv("LOG_TERMINAL_OUTPUT", "false")) == "true"
+        self._enable_output_logging = str.lower(
+            os.getenv("LOG_TERMINAL_OUTPUT", "false")) == "true"
 
     def origin_check(self, origin=None):
         """Deprecated: backward-compat for terminado <= 0.5."""
@@ -78,6 +81,7 @@ class TermSocket(tornado.websocket.WebSocketHandler):
             if content[0] == "stdout" and isinstance(content[1], str):
                 self.log_terminal_output(f"STDOUT: {content[1]}")
 
+    @gen.coroutine
     def on_message(self, message):
         """Handle incoming websocket message
 
@@ -89,7 +93,7 @@ class TermSocket(tornado.websocket.WebSocketHandler):
         msg_type = command[0]
         assert self.terminal is not None
         if msg_type == "stdin":
-            self.terminal.ptyproc.write(command[1])
+            yield self.stdin_to_ptyproc(command[1])
             if self._enable_output_logging:
                 if command[1] == "\r":
                     self.log_terminal_output(f"STDIN: {self._user_command}")
@@ -125,3 +129,14 @@ class TermSocket(tornado.websocket.WebSocketHandler):
         :return:
         """
         self._logger.debug(log)
+
+    @run_on_executor(executor='_blocking_io_executor')
+    def stdin_to_ptyproc(self, text):
+        """Handles stdin messages sent on the websocket.
+
+        This is a blocking call that should NOT be performed inside the
+        server primary event loop thread. Messages must be handled
+        asynchronously to prevent blocking on the PTY buffer.
+        """
+        if self.terminal is not None:
+            self.terminal.ptyproc.write(text)


### PR DESCRIPTION
A fix for #183 

This includes switching to using a dedicated executor for blocking IO, specifically wrapping calls to ptyprocess.write which, can hang when the PTY buffer (the size of which is set by the OS) is exceeded. TermSocket users can provide their own thread pool by using the named `blocking_io_executor` parameter on initialization, but by default a shared, process-wide single threaded executor will be used.

This also includes a regression test which will fail on Debian and OSX (but may be able to pass on some OSs due to the variance of the PTY buffer's size).

This also switched the default filetype of terminado/tests/basic_test.py from dos to unix to match with the rest of the files in this package and prevent some editors from auto-inserting carriage returns on save.