### PR TITLE
Maintenance cleanup

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -18,6 +18,6 @@ jobs:
         run: |
           pip install -e .
       - name: Check Release
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/install-minimums@v1
       - name: Run the unit tests
         run: |
-          pytest -vv || pytest -vv --lf
+          pytest -vv -W default || pytest -vv -W default --lf
 
   test_prereleases:
     name: Test Prereleases
@@ -74,7 +74,7 @@ jobs:
           pip check
       - name: Run the tests
         run: |
-          pytest -vv || pytest -vv --lf
+          pytest -vv -W default || pytest -vv -W default --lf
 
   make_sdist:
     name: Make SDist
@@ -111,26 +111,10 @@ jobs:
         with:
           package_name: jupyter_server_terminals
 
-  # Run "pre-commit run --all-files --hook-stage=manual"
   pre-commit:
     name: Run pre-commit hook
     runs-on: ubuntu-latest
-    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v3
-      - name: Run pre-commit
-        uses: pre-commit/action@v2.0.0
-        with:
-          extra_args: --all-files --hook-stage=manual
-      - name: Help message if pre-commit fail
-        if: ${{ failure() }}
-        run: |
-          echo "You can install pre-commit hooks to automatically run formatting"
-          echo "on each commit with:"
-          echo "    pre-commit install"
-          echo "or you can run by hand on staged files with"
-          echo "    pre-commit run"
-          echo "or after-the-fact on already committed files with"
-          echo "    pre-commit run --all-files --hook-stage=manual"
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/pre-commit@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
         files: \.py$
         args: [--profile=black]
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.1
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.10.1
     hooks:
-      - id: prettier
+      - id: validate-pyproject
+        stages: [manual]
+
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.16
+    hooks:
+      - id: mdformat
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,7 @@ content-type = "text/x-rst"
 Homepage = "https://github.com/jupyter/terminado"
 
 [project.optional-dependencies]
-test = [ "pytest>=6.0", "pre-commit", "pytest-timeout",]
-
-[tool.jupyter-releaser]
-skip = ["check-links"]
+test = [ "pytest>=7.0", "pre-commit", "pytest-timeout",]
 
 [tool.hatch.version]
 path = "terminado/__init__.py"


### PR DESCRIPTION
- Remove prettier and add pyproject validation and mdformat
- Use releaser v2
- Bump pytest dep to fix min version test
- Ignore warnings in prerelease and min version test
- Use new pre-commit action in maintainer-tools