### PR TITLE
Don't split manually on linebreaks

### DIFF
--- a/terminado/tests/basic_test.py
+++ b/terminado/tests/basic_test.py
@@ -119,9 +119,9 @@ class TestTermClient:
         else:
             # This should work on any OS, but keeping the above Windows special
             # case as I can't verify on Windows.
-            for l in stdout.splitlines():
-                if re.match(r"\d+$", l):
-                    pid = int(l)
+            for li in stdout.splitlines():
+                if re.match(r"\d+$", li):
+                    pid = int(li)
                     break
         return pid
 

--- a/terminado/tests/basic_test.py
+++ b/terminado/tests/basic_test.py
@@ -117,7 +117,12 @@ class TestTermClient:
             assert match is not None
             pid = int(match.groups()[0])
         else:
-            pid = int(stdout.split("\n")[1])
+            # This should work on any OS, but keeping the above Windows special
+            # case as I can't verify on Windows.
+            for l in stdout.splitlines():
+                if re.match(r"\d+$", l):
+                    pid = int(l)
+                    break
         return pid
 
     def close(self):


### PR DESCRIPTION
Use splitlines() instead of manually splitting on \r or  \n. Use the first line that looks like a PID (all numbers, as re.match only looks at the start of the line and the regex only allows numbers until end of line anchor).

Fixes https://github.com/jupyter/terminado/issues/84