### PR TITLE
Fix docs link to tornado WebSocketHandler

### DIFF
--- a/demos/templates/termpage.html
+++ b/demos/templates/termpage.html
@@ -84,8 +84,8 @@
     style="
       visibility: hidden;
       border: white solid 5px;
-      font-family: &quot;DejaVu Sans Mono&quot;, &quot;Liberation Mono&quot;,
-        monospace;
+      font-family:
+        &quot;DejaVu Sans Mono&quot;, &quot;Liberation Mono&quot;, monospace;
       font-size: 11px;
     "
   >0

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -257,7 +257,7 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"tornado": ("http://www.tornadoweb.org/en/stable/", None)}
+intersphinx_mapping = {"tornado": ("https://www.tornadoweb.org/en/stable/", None)}
 
 
 def setup(app):

--- a/doc/websocket.rst
+++ b/doc/websocket.rst
@@ -2,7 +2,7 @@ Using the TermSocket handler
 ============================
 
 :class:`terminado.TermSocket` is the main API in Terminado. It is a subclass of
-:class:`tornado.web.WebSocketHandler`, used to communicate between a
+:class:`tornado.websocket.WebSocketHandler`, used to communicate between a
 pseudoterminal and term.js. You add it to your web application as a handler like
 any other::
 


### PR DESCRIPTION
- Fix the link in the docs
- Fix the message printed during docs build: 
   ```
   intersphinx inventory has moved: http://www.tornadoweb.org/en/stable/objects.inv -> https://www.tornadoweb.org/en/stable/objects.inv
   ```